### PR TITLE
Add Transactional annotations to DAO methods that modify db state

### DIFF
--- a/src/main/java/bio/terra/folder/app/configuration/ApplicationConfiguration.java
+++ b/src/main/java/bio/terra/folder/app/configuration/ApplicationConfiguration.java
@@ -15,11 +15,9 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
 @EnableConfigurationProperties
-@EnableTransactionManagement
 @ConfigurationProperties(prefix = "folder")
 public class ApplicationConfiguration {
 

--- a/src/main/java/bio/terra/folder/app/configuration/StairwayJdbcConfiguration.java
+++ b/src/main/java/bio/terra/folder/app/configuration/StairwayJdbcConfiguration.java
@@ -3,11 +3,9 @@ package bio.terra.folder.app.configuration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Component
 @EnableConfigurationProperties
-@EnableTransactionManagement
 @ConfigurationProperties(prefix = "db.stairway")
 public class StairwayJdbcConfiguration extends JdbcConfiguration {
   private String migrateUpgrade;

--- a/src/main/java/bio/terra/folder/db/FolderDao.java
+++ b/src/main/java/bio/terra/folder/db/FolderDao.java
@@ -9,6 +9,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class FolderDao {
@@ -19,6 +22,7 @@ public class FolderDao {
     this.jdbcTemplate = jdbcTemplate;
   }
 
+  @Transactional(propagation =  Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public void createFolder(
       String folderId,
       String folderName,
@@ -39,6 +43,7 @@ public class FolderDao {
     jdbcTemplate.update(sql, paramMap);
   }
 
+  @Transactional(propagation =  Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public boolean deleteFolder(String folderId) {
     String sql = "DELETE FROM folder WHERE folder_id = :id";
     Map<String, Object> paramMap = new HashMap<>();


### PR DESCRIPTION
See https://github.com/DataBiosphere/terra-workspace-manager/pull/11 for the same change in Workspace Manager.

The Transactional annotation indicates that methods of this class should be executed as transactions (i.e. they atomically succeed or fail).
The propagation setting ensures these methods always execute as transactions, or become part of larger transactions if called from inside another transaction. Although this is the default setting, I include it for clarity.
The isolation setting ensures these methods execute sequentially, preventing interference caused by multiple simultaneous read/write transactions.

The EnableTransactionManagement annotation is used to mark a Configuration bean as in charge of Transactions (indicated by the Transactional annotation). In this service, this should only be the FolderManagerJdbcConfiguration.