### PR TITLE
Refactor CreateService to FolderService

### DIFF
--- a/src/main/java/bio/terra/folder/app/controller/FolderApiController.java
+++ b/src/main/java/bio/terra/folder/app/controller/FolderApiController.java
@@ -4,7 +4,7 @@ import bio.terra.folder.generated.controller.FolderApi;
 import bio.terra.folder.generated.model.CreateFolderBody;
 import bio.terra.folder.generated.model.CreatedFolder;
 import bio.terra.folder.generated.model.JobModel;
-import bio.terra.folder.service.create.CreateService;
+import bio.terra.folder.service.folder.FolderService;
 import bio.terra.folder.service.iam.AuthenticatedUserRequest;
 import bio.terra.folder.service.iam.AuthenticatedUserRequestFactory;
 import bio.terra.folder.service.job.JobService;
@@ -20,18 +20,18 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Controller
 public class FolderApiController implements FolderApi {
   private JobService jobService;
-  private CreateService createService;
+  private FolderService folderService;
   private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
   private final HttpServletRequest request;
 
   @Autowired
   public FolderApiController(
       JobService jobService,
-      CreateService createService,
+      FolderService folderService,
       AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
       HttpServletRequest request) {
     this.jobService = jobService;
-    this.createService = createService;
+    this.folderService = folderService;
     this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
     this.request = request;
   }
@@ -44,7 +44,7 @@ public class FolderApiController implements FolderApi {
   public ResponseEntity<CreatedFolder> createFolder(
       @RequestBody CreateFolderBody createFolderBody) {
     return new ResponseEntity<>(
-        createService.createFolder(createFolderBody, getAuthenticatedInfo()), HttpStatus.OK);
+        folderService.createFolder(createFolderBody, getAuthenticatedInfo()), HttpStatus.OK);
   }
 
   @Override

--- a/src/main/java/bio/terra/folder/service/folder/FolderService.java
+++ b/src/main/java/bio/terra/folder/service/folder/FolderService.java
@@ -1,13 +1,13 @@
-package bio.terra.folder.service.create;
+package bio.terra.folder.service.folder;
 
 import bio.terra.folder.db.FolderDao;
 import bio.terra.folder.generated.model.CreateFolderBody;
 import bio.terra.folder.generated.model.CreatedFolder;
-import bio.terra.folder.service.create.exception.InvalidNameException;
-import bio.terra.folder.service.create.exception.InvalidSpendProfileException;
-import bio.terra.folder.service.create.exception.NameConflictException;
-import bio.terra.folder.service.create.flight.FolderCreateFlight;
-import bio.terra.folder.service.create.flight.FolderFlightMapKeys;
+import bio.terra.folder.service.folder.exception.InvalidNameException;
+import bio.terra.folder.service.folder.exception.InvalidSpendProfileException;
+import bio.terra.folder.service.folder.exception.NameConflictException;
+import bio.terra.folder.service.folder.flight.FolderCreateFlight;
+import bio.terra.folder.service.folder.flight.FolderFlightMapKeys;
 import bio.terra.folder.service.iam.AuthenticatedUserRequest;
 import bio.terra.folder.service.job.JobBuilder;
 import bio.terra.folder.service.job.JobService;
@@ -15,15 +15,17 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
 
+// Service for managing actions related to Folder CRUD operations. Operations for managing contained
+// objects belong in a separate service.
 @Component
-public class CreateService {
+public class FolderService {
 
   public static Pattern validNamePattern = Pattern.compile("^[\\w\\-\\s_]+$");
 
   private JobService jobService;
   private FolderDao folderDao;
 
-  public CreateService(JobService jobService, FolderDao folderDao) {
+  public FolderService(JobService jobService, FolderDao folderDao) {
     this.jobService = jobService;
     this.folderDao = folderDao;
   }

--- a/src/main/java/bio/terra/folder/service/folder/exception/InvalidNameException.java
+++ b/src/main/java/bio/terra/folder/service/folder/exception/InvalidNameException.java
@@ -1,4 +1,4 @@
-package bio.terra.folder.service.create.exception;
+package bio.terra.folder.service.folder.exception;
 
 import bio.terra.folder.common.exception.BadRequestException;
 

--- a/src/main/java/bio/terra/folder/service/folder/exception/InvalidSpendProfileException.java
+++ b/src/main/java/bio/terra/folder/service/folder/exception/InvalidSpendProfileException.java
@@ -1,4 +1,4 @@
-package bio.terra.folder.service.create.exception;
+package bio.terra.folder.service.folder.exception;
 
 import bio.terra.folder.common.exception.BadRequestException;
 

--- a/src/main/java/bio/terra/folder/service/folder/exception/NameConflictException.java
+++ b/src/main/java/bio/terra/folder/service/folder/exception/NameConflictException.java
@@ -1,4 +1,4 @@
-package bio.terra.folder.service.create.exception;
+package bio.terra.folder.service.folder.exception;
 
 import bio.terra.folder.common.exception.BadRequestException;
 

--- a/src/main/java/bio/terra/folder/service/folder/flight/CreateFolderStep.java
+++ b/src/main/java/bio/terra/folder/service/folder/flight/CreateFolderStep.java
@@ -1,4 +1,4 @@
-package bio.terra.folder.service.create.flight;
+package bio.terra.folder.service.folder.flight;
 
 import bio.terra.folder.common.utils.FlightUtils;
 import bio.terra.folder.db.FolderDao;

--- a/src/main/java/bio/terra/folder/service/folder/flight/FolderCreateFlight.java
+++ b/src/main/java/bio/terra/folder/service/folder/flight/FolderCreateFlight.java
@@ -1,4 +1,4 @@
-package bio.terra.folder.service.create.flight;
+package bio.terra.folder.service.folder.flight;
 
 import bio.terra.folder.db.FolderDao;
 import bio.terra.folder.generated.model.CreateFolderBody;

--- a/src/main/java/bio/terra/folder/service/folder/flight/FolderFlightMapKeys.java
+++ b/src/main/java/bio/terra/folder/service/folder/flight/FolderFlightMapKeys.java
@@ -1,4 +1,4 @@
-package bio.terra.folder.service.create.flight;
+package bio.terra.folder.service.folder.flight;
 
 public class FolderFlightMapKeys {
   private FolderFlightMapKeys() {}

--- a/src/test/java/bio/terra/folder/service/folder/FolderServiceTest.java
+++ b/src/test/java/bio/terra/folder/service/folder/FolderServiceTest.java
@@ -1,4 +1,4 @@
-package bio.terra.folder.service.create;
+package bio.terra.folder.service.folder;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.blankOrNullString;
@@ -37,7 +37,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @ContextConfiguration(classes = Main.class)
 @SpringBootTest
 @AutoConfigureMockMvc
-public class CreateServiceTest {
+public class FolderServiceTest {
 
   @Autowired private MockMvc mvc;
 
@@ -46,7 +46,7 @@ public class CreateServiceTest {
 
   @Autowired private ObjectMapper objectMapper;
 
-  @Autowired private CreateService createService;
+  @Autowired private FolderService folderService;
 
   @BeforeEach
   public void setup() {


### PR DESCRIPTION
Similar to the current refactoring in WorkspaceManager, it seems easier to organize services by the objects they act on, rather than the product of "actions" and "objects".